### PR TITLE
add support for dynamic collection of test-jars.xml

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -72,3 +72,43 @@ your module in which you'd like to run them can seamlessly use them as `test` sc
   </executions>
 </plugin>
 ----
+
+== Test Catalog XML
+To provide a way how to easily rerun the desired tests, the maven-plugin implements goal `create-test-jars-file`.
+This goal creates an xml catalog containing all the `groupId:artifacId` pairs as configured within the project.
+
+=== Configuration options
+*Static* - the included `groupId:artifactId` pairs are read from the filesystem based on provided configuration as:
+----
+<execution>
+  <id>create-test-jars</id>
+  <inherited>false</inherited>
+  <goals>
+    <goal>create-test-jars-file</goal>
+  </goals>
+  <configuration>
+    <testJarsPath>${project.basedir}/test-jars.xml</testJarsPath>
+    <fileSets>
+      <fileSet>
+        <directory>${basedir}/..</directory>
+        <includes>testable-*/pom.xml</includes>
+      </fileSet>
+    </fileSets>
+  </configuration>
+</execution>
+----
+*Dynamic* - the included `groupId:artifactId` pairs are dynamically collected from the maven reactor build,
+based on a predefined filtering property (if it's set to true, the module is collected):
+----
+<execution>
+  <id>create-test-jars</id>
+  <inherited>false</inherited>
+  <goals>
+    <goal>create-test-jars-file</goal>
+  </goals>
+  <configuration>
+    <testJarsPath>${project.build.directory}/test-jars.xml</testJarsPath>
+    <activatingPropertyName>rpkgtests-activating-property</activatingPropertyName>
+  </configuration>
+</execution>
+----

--- a/pom.xml
+++ b/pom.xml
@@ -584,6 +584,7 @@ limitations under the License.</inlineHeader>
         <artifactId>formatter-maven-plugin</artifactId>
         <configuration>
           <configFile>eclipse-format.xml</configFile>
+          <lineEnding>LF</lineEnding>
           <skip>${format.skip}</skip>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 
     <!-- Plugins and their dependencies -->
     <version.com.github.github.site-maven-plugin>0.12</version.com.github.github.site-maven-plugin>
-    <version.com.mycila.license-maven-plugin>3.0</version.com.mycila.license-maven-plugin>
+    <version.com.mycila.license-maven-plugin>4.1</version.com.mycila.license-maven-plugin>
     <version.formatter-maven-plugin>2.11.0</version.formatter-maven-plugin>
     <version.impsort-maven-plugin>1.3.2</version.impsort-maven-plugin>
     <version.maven-antrun-plugin>1.8</version.maven-antrun-plugin>
@@ -323,7 +323,7 @@
           <artifactId>license-maven-plugin</artifactId>
           <version>${version.com.mycila.license-maven-plugin}</version>
           <configuration>
-            <inlineHeader>Copyright (c) ${project.inceptionYear} Repackage Tests Maven Plugin
+            <inlineHeader>Copyright (c) ${license.git.copyrightCreationYear} Repackage Tests Maven Plugin
 project contributors as indicated by the @author tags.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -349,6 +349,9 @@ limitations under the License.</inlineHeader>
               <exclude>mvnw</exclude>
               <exclude>mvnw.cmd</exclude>
             </excludes>
+            <properties>
+              <license.git.copyrightLastYearMaxCommitsLookup>100</license.git.copyrightLastYearMaxCommitsLookup>
+            </properties>
           </configuration>
           <executions>
             <execution>
@@ -357,6 +360,13 @@ limitations under the License.</inlineHeader>
               </goals>
             </execution>
           </executions>
+          <dependencies>
+            <dependency>
+              <groupId>com.mycila</groupId>
+              <artifactId>license-maven-plugin-git</artifactId>
+              <version>${version.com.mycila.license-maven-plugin}</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <plugin>

--- a/src/it/create-test-jars-dynamic/lib/pom.xml
+++ b/src/it/create-test-jars-dynamic/lib/pom.xml
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright (c) 2021 Repackage Tests Maven Plugin
+    project contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.l2x6.rpkgtests.create-test-jars-dynamic</groupId>
+    <artifactId>create-test-jars-dynamic-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>create-test-jars-lib</artifactId>
+
+</project>

--- a/src/it/create-test-jars-dynamic/lib/src/main/java/org/l2x6/rpkgtests/create/test/jars/lib/HelloLib.java
+++ b/src/it/create-test-jars-dynamic/lib/src/main/java/org/l2x6/rpkgtests/create/test/jars/lib/HelloLib.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2021 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/it/create-test-jars-dynamic/lib/src/main/java/org/l2x6/rpkgtests/create/test/jars/lib/HelloLib.java
+++ b/src/it/create-test-jars-dynamic/lib/src/main/java/org/l2x6/rpkgtests/create/test/jars/lib/HelloLib.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2021 Repackage Tests Maven Plugin
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.l2x6.rpkgtests.create.test.jars.lib;
+
+public class HelloLib {
+    public String hello() {
+        return "Hello";
+    }
+}

--- a/src/it/create-test-jars-dynamic/pom.xml
+++ b/src/it/create-test-jars-dynamic/pom.xml
@@ -1,0 +1,119 @@
+<!--
+
+    Copyright (c) 2021 Repackage Tests Maven Plugin
+    project contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.l2x6.rpkgtests.create-test-jars-dynamic</groupId>
+  <artifactId>create-test-jars-dynamic-parent</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <rpkgtests-maven-plugin.version>@pom.version@</rpkgtests-maven-plugin.version>
+
+    <!-- maven-compiler-plugin -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <modules>
+    <module>lib</module>
+    <module>testable-1</module>
+    <module>testable-2</module>
+  </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>5.4.0</version>
+      </dependency>
+    </dependencies>
+
+  </dependencyManagement>
+
+  <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.l2x6.rpkgtests</groupId>
+          <artifactId>rpkgtests-maven-plugin</artifactId>
+          <version>${rpkgtests-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.l2x6.rpkgtests</groupId>
+        <artifactId>rpkgtests-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-test-jars</id>
+            <inherited>false</inherited>
+            <goals>
+              <goal>create-test-jars-file</goal>
+            </goals>
+            <configuration>
+              <testJarsPath>${project.build.directory}/test-jars.xml</testJarsPath>
+              <activatingPropertyName>rpkgtests-activating-property</activatingPropertyName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+  </build>
+  <profiles>
+    <profile>
+      <id>additonal-modules-to-reactor</id>
+      <activation>
+        <property>
+          <name>!reduced-reactor</name>
+        </property>
+      </activation>
+      <modules>
+        <module>testable-3</module>
+      </modules>
+    </profile>
+  </profiles>
+</project>

--- a/src/it/create-test-jars-dynamic/postbuild.groovy
+++ b/src/it/create-test-jars-dynamic/postbuild.groovy
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2021 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/it/create-test-jars-dynamic/postbuild.groovy
+++ b/src/it/create-test-jars-dynamic/postbuild.groovy
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2021 Repackage Tests Maven Plugin
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Path
+import java.nio.file.Files
+
+final Path baseDir = basedir.toPath();
+
+assertFilesEqual(baseDir, 'test-jars.expected.xml', 'target/test-jars.xml')
+
+// Methods
+
+void assertFilesEqual(Path baseDir, String expectedPath, String actualPath) {
+    final String actual = new String(Files.readAllBytes(baseDir.resolve(actualPath)), 'UTF-8')
+    final String expected = new String(Files.readAllBytes(baseDir.resolve(expectedPath)), 'UTF-8')
+    assert expected.equals(actual) : "" + expectedPath + " does not equal " + actualPath
+}

--- a/src/it/create-test-jars-dynamic/test-jars.expected.xml
+++ b/src/it/create-test-jars-dynamic/test-jars.expected.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<testArtifacts>
+    <testArtifact>
+        <groupId>org.l2x6.rpkgtests.create-test-jars-dynamic</groupId>
+        <artifactId>create-test-jars-testable-1</artifactId>
+    </testArtifact>
+    <testArtifact>
+        <groupId>org.l2x6.rpkgtests.create-test-jars-dynamic</groupId>
+        <artifactId>create-test-jars-testable-3</artifactId>
+    </testArtifact>
+</testArtifacts>

--- a/src/it/create-test-jars-dynamic/testable-1/pom.xml
+++ b/src/it/create-test-jars-dynamic/testable-1/pom.xml
@@ -1,0 +1,48 @@
+<!--
+
+    Copyright (c) 2021 Repackage Tests Maven Plugin
+    project contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.l2x6.rpkgtests.create-test-jars-dynamic</groupId>
+    <artifactId>create-test-jars-dynamic-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>create-test-jars-testable-1</artifactId>
+  <properties>
+    <rpkgtests-activating-property>true</rpkgtests-activating-property>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.l2x6.rpkgtests.create-test-jars-dynamic</groupId>
+      <artifactId>create-test-jars-lib</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/src/it/create-test-jars-dynamic/testable-1/src/test/java/org/l2x6/rpkgtests/create/test/jars/test1/Hello1Test.java
+++ b/src/it/create-test-jars-dynamic/testable-1/src/test/java/org/l2x6/rpkgtests/create/test/jars/test1/Hello1Test.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2021 Repackage Tests Maven Plugin
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.l2x6.rpkgtests.create.test.jars.test1;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.l2x6.rpkgtests.create.test.jars.lib.HelloLib;
+
+public class Hello1Test {
+
+    @Test
+    void hello() {
+        Assertions.assertEquals("Hello", new HelloLib().hello());
+    }
+
+}

--- a/src/it/create-test-jars-dynamic/testable-1/src/test/java/org/l2x6/rpkgtests/create/test/jars/test1/Hello1Test.java
+++ b/src/it/create-test-jars-dynamic/testable-1/src/test/java/org/l2x6/rpkgtests/create/test/jars/test1/Hello1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2021 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/it/create-test-jars-dynamic/testable-2/pom.xml
+++ b/src/it/create-test-jars-dynamic/testable-2/pom.xml
@@ -1,0 +1,47 @@
+<!--
+
+    Copyright (c) 2021 Repackage Tests Maven Plugin
+    project contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.l2x6.rpkgtests.create-test-jars-dynamic</groupId>
+    <artifactId>create-test-jars-dynamic-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>create-test-jars-testable-2</artifactId>
+  <properties>
+    <rpkgtests-activating-property>false</rpkgtests-activating-property>
+  </properties>
+  <dependencies>
+
+    <dependency>
+      <groupId>org.l2x6.rpkgtests.create-test-jars-dynamic</groupId>
+      <artifactId>create-test-jars-lib</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/src/it/create-test-jars-dynamic/testable-2/src/test/java/org/l2x6/rpkgtests/create/test/jars/test2/Hello2Test.java
+++ b/src/it/create-test-jars-dynamic/testable-2/src/test/java/org/l2x6/rpkgtests/create/test/jars/test2/Hello2Test.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2021 Repackage Tests Maven Plugin
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.l2x6.rpkgtests.create.test.jars.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.l2x6.rpkgtests.create.test.jars.lib.HelloLib;
+
+public class Hello2Test {
+
+    @Test
+    void hello() {
+        Assertions.assertEquals("Hello", new HelloLib().hello());
+    }
+
+}

--- a/src/it/create-test-jars-dynamic/testable-2/src/test/java/org/l2x6/rpkgtests/create/test/jars/test2/Hello2Test.java
+++ b/src/it/create-test-jars-dynamic/testable-2/src/test/java/org/l2x6/rpkgtests/create/test/jars/test2/Hello2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2021 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/it/create-test-jars-dynamic/testable-3/pom.xml
+++ b/src/it/create-test-jars-dynamic/testable-3/pom.xml
@@ -1,0 +1,48 @@
+<!--
+
+    Copyright (c) 2021 Repackage Tests Maven Plugin
+    project contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.l2x6.rpkgtests.create-test-jars-dynamic</groupId>
+    <artifactId>create-test-jars-dynamic-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>create-test-jars-testable-3</artifactId>
+  <properties>
+    <rpkgtests-activating-property>true</rpkgtests-activating-property>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.l2x6.rpkgtests.create-test-jars-dynamic</groupId>
+      <artifactId>create-test-jars-lib</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/src/it/create-test-jars-dynamic/testable-3/src/test/java/org/l2x6/rpkgtests/create/test/jars/test1/Hello1Test.java
+++ b/src/it/create-test-jars-dynamic/testable-3/src/test/java/org/l2x6/rpkgtests/create/test/jars/test1/Hello1Test.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2021 Repackage Tests Maven Plugin
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.l2x6.rpkgtests.create.test.jars.test1;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.l2x6.rpkgtests.create.test.jars.lib.HelloLib;
+
+public class Hello1Test {
+
+    @Test
+    void hello() {
+        Assertions.assertEquals("Hello", new HelloLib().hello());
+    }
+
+}

--- a/src/it/create-test-jars-dynamic/testable-3/src/test/java/org/l2x6/rpkgtests/create/test/jars/test1/Hello1Test.java
+++ b/src/it/create-test-jars-dynamic/testable-3/src/test/java/org/l2x6/rpkgtests/create/test/jars/test1/Hello1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2021 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/it/create-test-jars/create/src/main/java/org/l2x6/rpkgtests/create/test/jars/lib/HelloLib.java
+++ b/src/it/create-test-jars/create/src/main/java/org/l2x6/rpkgtests/create/test/jars/lib/HelloLib.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/it/create-test-jars/lib/src/main/java/org/l2x6/rpkgtests/create/test/jars/lib/HelloLib.java
+++ b/src/it/create-test-jars/lib/src/main/java/org/l2x6/rpkgtests/create/test/jars/lib/HelloLib.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/it/create-test-jars/postbuild.groovy
+++ b/src/it/create-test-jars/postbuild.groovy
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/it/create-test-jars/prebuild.groovy
+++ b/src/it/create-test-jars/prebuild.groovy
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import java.nio.file.Path
 import java.nio.file.Files
 

--- a/src/it/create-test-jars/testable-1/src/test/java/org/l2x6/rpkgtests/create/test/jars/test1/Hello1Test.java
+++ b/src/it/create-test-jars/testable-1/src/test/java/org/l2x6/rpkgtests/create/test/jars/test1/Hello1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/it/create-test-jars/testable-2/src/test/java/org/l2x6/rpkgtests/create/test/jars/test2/Hello2Test.java
+++ b/src/it/create-test-jars/testable-2/src/test/java/org/l2x6/rpkgtests/create/test/jars/test2/Hello2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/main/java/org/l2x6/rpkgtests/AbstractTestJarsConsumerMojo.java
+++ b/src/main/java/org/l2x6/rpkgtests/AbstractTestJarsConsumerMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/main/java/org/l2x6/rpkgtests/CreateTestJarsXmlMojo.java
+++ b/src/main/java/org/l2x6/rpkgtests/CreateTestJarsXmlMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/main/java/org/l2x6/rpkgtests/Ga.java
+++ b/src/main/java/org/l2x6/rpkgtests/Ga.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/main/java/org/l2x6/rpkgtests/Gas.java
+++ b/src/main/java/org/l2x6/rpkgtests/Gas.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/main/java/org/l2x6/rpkgtests/Gav.java
+++ b/src/main/java/org/l2x6/rpkgtests/Gav.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/main/java/org/l2x6/rpkgtests/GenerateTestModulesMojo.java
+++ b/src/main/java/org/l2x6/rpkgtests/GenerateTestModulesMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/main/java/org/l2x6/rpkgtests/RepackageAndInstallTestJarsMojo.java
+++ b/src/main/java/org/l2x6/rpkgtests/RepackageAndInstallTestJarsMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/main/java/org/l2x6/rpkgtests/RpkgUtils.java
+++ b/src/main/java/org/l2x6/rpkgtests/RpkgUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *

--- a/src/test/java/org/l2x6/rpkgtests/GenerateTestModulesMojoTest.java
+++ b/src/test/java/org/l2x6/rpkgtests/GenerateTestModulesMojoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Repackage Tests Maven Plugin
  * project contributors as indicated by the @author tags.
  *


### PR DESCRIPTION
Adding support for dynamic test-jars.xml collection based on contents of Maven reactor.
Filtering of modules included can be done using a pre-defined configurable property, which is evaluated for each project in reactor.